### PR TITLE
fix: DHFPay::request fails to return a response if guzzle middleware is used

### DIFF
--- a/src/DHFPay.php
+++ b/src/DHFPay.php
@@ -77,7 +77,7 @@ class DHFPay
     {
         try {
 
-            $newresponse = $this->client->request(
+            $newresponse = (string)$this->client->request(
                 $method,
                 $uri,
                 [
@@ -88,7 +88,7 @@ class DHFPay
                         ],
                     RequestOptions::JSON => $body
                 ]
-            )->getBody()->getContents();
+            )->getBody();
 
         } catch (RequestException $exception) {
             throw $this->processException($exception);


### PR DESCRIPTION
If we override $client in an inherited class, adding some middleware, calling `request` method leads to fatal error:

```
Return value of DHF\Pay\DHFPay::request() must be of the type array, null returned
```

See: https://stackoverflow.com/a/30549372